### PR TITLE
Update landingPage authorisation

### DIFF
--- a/DATS.json
+++ b/DATS.json
@@ -69,7 +69,7 @@
                 "landingPage" : "https://portal.cbrain.mcgill.ca/userfiles/5126312",
 				"authorizations": [
 					{
-						"value": "private"
+						"value": "registered"
 					}
 				]
             }


### PR DESCRIPTION
This PR updates the `landingPage` authorisation value in `DATS.json` from "private" to "registered".